### PR TITLE
Revert "rename deprecated JSON to search"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ disableHomeIcon = false
 disableNavChevron = false
 
 [outputs]
-home = [ "HTML", "RSS", "search" ]
+home = [ "HTML", "RSS", "JSON" ]
 
 [markup.goldmark.renderer]
 unsafe = true


### PR DESCRIPTION
This reverts commit 6cb65ab9583f24fd5a149e782ccf8dd57a40079a.

Fixes nix-community/nur-search#18.

The JSON format doesn't appear to actually be deprecated:

<https://gohugo.io/templates/output-formats/#media-types>

The only reference I can find to 'JSON' being deprecated in favor of 'search' is talking about the Relearn theme's custom output types, not Hugo's builtin ones:

<https://mcshelby.github.io/hugo-theme-relearn/basics/migration/index.html#540>