### PR TITLE
fix deprecated `.Site.IsMultiLingual` -> `.Site.IsMultiLingual`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/docdock"]
 	path = themes/docdock
-	url = https://github.com/vjeantet/hugo-theme-docdock/
+	url = https://github.com/Rhys-T/hugo-theme-docdock/

--- a/layouts/partials/nur/body-beforecontent.html
+++ b/layouts/partials/nur/body-beforecontent.html
@@ -54,7 +54,7 @@
         <script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
         <link href="{{"css/auto-complete.css" | relURL}}" rel="stylesheet">
         <script type="text/javascript">
-          {{ if .Site.IsMultiLingual }}
+          {{ if hugo.IsMultilingual }}
               var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
           {{ else }}
               var baseurl = "{{.Site.BaseURL}}";


### PR DESCRIPTION
Updates docDock theme to a fork of a newer version. Fixes #21.